### PR TITLE
fix: keep only cookie based userinfo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,8 @@ $ docker system prune -a && \
 
 **Run a Docker container based on the image:**
 ```bash
-$ NGINX_CONF_PATH=/Users/{your user name}/{your github path}/nginx-openid-connect/examples/context/nginx/conf.d
+$ NGINX_CONF_PATH=/Users/{user name}/{your github path}/examples/context/nginx/conf.d
+$ NGINX_HTML_PATH=/Users/{user name}/{your github path}/examples/build-context/content
 $ docker-compose up -d
 ```
 

--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -483,7 +483,7 @@ function isValidNonceClaim(r, msgPrefix) {
             clientNonceHash = h.digest('base64url');
         }
         if (r.variables.jwt_claim_nonce != clientNonceHash) {
-            r.error(ERR_ID_TOKEN + 'nonce from token (' + 
+            r.error(msgPrefix + 'nonce from token (' + 
                 r.variables.jwt_claim_nonce + ') does not match client (' + 
                 clientNonceHash + ')');
             return false;

--- a/examples/build-context/nginx/conf.d/oidc_server.conf
+++ b/examples/build-context/nginx/conf.d/oidc_server.conf
@@ -78,25 +78,28 @@
 
     # Retrieve user information w/ cookie + bearer access token
     #
-    # Reponse Example:
+    # Reponse Example 1 (Amazon Cognito):
     # {
     #     "sub"     : "bbd06af9-9516-48c4-aa23-5898df7ed990",
     #     "email"   : "user-01@nginx.com",
     #     "username": "user-01"
     # }
+    #
+    # Reponse Example 2 (OneLogin):
+    # {
+    #     "sub"               : "149767934",
+    #     "email"             : "user-02@nginx.com",
+    #     "name"              : "Super Man",
+    #     "updated_at"        : 1632264185,
+    #     "given_name"        : "Super",
+    #     "family_name"       : "Man"
+    # }
+    #
     location = /userinfo {
-        status_zone "OIDC userinfo I";
+        status_zone "OIDC userinfo";
         auth_jwt "" token=$access_token;
         auth_jwt_key_request /_jwks_uri;
         proxy_set_header Authorization "Bearer $access_token";
-        proxy_pass       $oidc_userinfo_endpoint;
-    }
-
-    # Retrieve user information w/ bearer access token w/o cookie
-    location = /user_info {
-        status_zone "OIDC userinfo II";
-        auth_jwt "";
-        auth_jwt_key_request /_jwks_uri;
         proxy_pass       $oidc_userinfo_endpoint;
     }
 


### PR DESCRIPTION
- keep only cookie based user info retrival.
- remove bearer token based `GET /user_info`.
- fix additional prefix in the error message for validating `nonce` claim.