### PR TITLE
fix: New session JWT and refresh token

### DIFF
--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -333,7 +333,7 @@ function handleSuccessfulTokenResponse(r, res) {
         }
 
         // Add opaque ID token and access token to key/value store
-        r.variables.new_session      = tokenset.id_token;
+        r.variables.new_id_token     = tokenset.id_token;
         r.variables.new_access_token = tokenset.access_token;
 
         // Add new refresh token to key/value store

--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -152,17 +152,17 @@ proxy_cache_path /var/cache/nginx/jwk levels=1 keys_zone=jwk:64k max_size=1m;
 # Change timeout values to at least the validity period of each token type
 keyval_zone zone=oidc_id_tokens:1M       state=conf.d/oidc_id_tokens.json      timeout=1h;
 keyval_zone zone=oidc_access_tokens:1M   state=conf.d/oidc_access_tokens.json  timeout=1h;
-keyval_zone zone=refresh_tokens:1M       state=conf.d/oidc_refresh_tokens.json timeout=8h;
+keyval_zone zone=oidc_refresh_tokens:1M  state=conf.d/oidc_refresh_tokens.json timeout=8h;
 
 # Temporary storage for PKCE code verifier.
 keyval_zone zone=oidc_pkce:128K                                                timeout=90s;
 
 keyval $cookie_auth_token $id_token           zone=oidc_id_tokens;       # Exchange cookie for ID      token
 keyval $cookie_auth_token $access_token       zone=oidc_access_tokens;   # Exchange cookie for access  token
-keyval $cookie_auth_token $refresh_token      zone=refresh_tokens;       # Exchange cookie for refresh token
-keyval $request_id        $new_session        zone=oidc_id_tokens;       # For initial session creation for ID token
+keyval $cookie_auth_token $refresh_token      zone=oidc_refresh_tokens;  # Exchange cookie for refresh token
+keyval $request_id        $new_id_token       zone=oidc_id_tokens;       # For initial session creation for ID token
 keyval $request_id        $new_access_token   zone=oidc_access_tokens;   # For initial session creation for access token
-keyval $request_id        $new_refresh        zone=refresh_tokens;       # ''
+keyval $request_id        $new_refresh        zone=oidc_refresh_tokens;  # ''
 keyval $pkce_id           $pkce_code_verifier zone=oidc_pkce;
 
 auth_jwt_claim_set $jwt_audience aud; # In case aud is an array


### PR DESCRIPTION
- Change new session JWT to ID token
- Change the name from `refresh_token` to `oidc_refresh_token` for consistent naming