### PR TITLE
feat: return token to client on login and backend

### DIFF
--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -59,7 +59,7 @@ map $host $oidc_logout_endpoint {
 }
 
 map $host $oidc_pkce_enable {
-    default 0;
+    default                 0;
     mynginxoidc.aws         0;
     mynginxpkce.aws         1;
     mynginxoidc.onelogin    0;
@@ -144,6 +144,30 @@ map $http_x_forwarded_proto $proto {
 
 map $host $post_logout_return_uri {
     default $redirect_base;
+}
+
+map $host $return_token_to_client_on_login {
+    # This is only effective for /login endpoint exposed. By default,
+    # this implementation MUST not return any token back to the client app. 
+    # If its configured it can send id_token in the request uri 
+    # as ?id_token=sdfsdfdsfs after successful login.
+    default  "id_token"; # options: id_token or ""
+}
+
+map $host $return_token_to_backend {
+    # This is always effective as default this forward access_token as Bearer token.
+    # However this can be configured to just forward the id_token in the request 
+    # header as `x-id-token=sdfdsfdsfds`. If its configured to forward both then
+    # the proxy request header would have:
+    #   Authorization : Bearer <access_token> & x-id-token : sdfdsfdsfds. If its
+    #   configured as none then NO token(s) get forwarded to the backend service.
+    default "access_token"; # options: access_token, id_token, "", or both
+}
+
+map $proxy_id $backend_proxy {
+    default     http://my_backend_api;
+    'proxy_4'   http://my_backend_api;
+    'proxy_5'   http://my_backend_api;
 }
 
 # ADVANCED CONFIGURATION BELOW THIS LINE

--- a/examples/build-context/nginx/conf.d/oidc_server.conf
+++ b/examples/build-context/nginx/conf.d/oidc_server.conf
@@ -1,6 +1,7 @@
     # Advanced configuration START
     set $internal_error_message "NGINX / OIDC login failure\n";
     set $pkce_id "";
+    set $proxy_id "";
     resolver 8.8.8.8; # For DNS lookup of IdP endpoints;
     subrequest_output_buffer_size 32k; # To fit a complete tokenset response
     gunzip on; # Decompress IdP responses if necessary
@@ -76,6 +77,31 @@
         error_page 500 502 504 @oidc_error;
     }
 
+    location = /_proxy_with_access_token {
+        # This location is called by passProxyWithAccessToken().
+        internal;
+        auth_jwt "" token=$access_token;
+        proxy_set_header Authorization "Bearer $access_token";
+        proxy_pass $backend_proxy$request_uri;
+    }
+
+    location = /_proxy_with_id_token {
+        # This location is called by passProxyWithIdToken().
+        internal;
+        auth_jwt "" token=$id_token;
+        proxy_set_header x-id-token    "$id_token";
+        proxy_pass $backend_proxy$request_uri;
+    }
+
+    location = /_proxy_with_id_access_token {
+        # This location is called by passProxyWithIdAccessToken().
+        internal;
+        auth_jwt "" token=$access_token;
+        proxy_set_header Authorization "Bearer $access_token";
+        proxy_set_header x-id-token    "$id_token";
+        proxy_pass $backend_proxy$request_uri;
+    }
+
     location = /userinfo {
         # This location is called by UI to retrieve user info w/ cookie + bearer
         # access token.
@@ -119,6 +145,7 @@
         auth_jwt_key_request /_jwks_uri;        # Enable when using URL
 
         # Redirect to the the original URI of UI after logging-in IDP.
+        default_type application/json;
         js_content oidc.redirectPostLogin;
         access_log /var/log/nginx/access.log main_jwt;
     }

--- a/examples/build-context/nginx/conf.d/sample_location_api.conf
+++ b/examples/build-context/nginx/conf.d/sample_location_api.conf
@@ -7,9 +7,7 @@
     # For testing a proxied backend API without access token.
     location /v1/api/1 {
         status_zone api_1;
-
         proxy_pass  http://localhost:9090/v1/api/1;
-
         access_log /var/log/nginx/access.log main;
     }
 
@@ -39,7 +37,7 @@
     # For testing a proxied backend API w/ bearer token without cookie:
     location /v1/api/3 {
         status_zone api_3;
-        
+
         # The optional token parameter specifies a variable that contains JWT.
         # By default, it is passed in the “Authorization” header as a Bearer Token.
         #
@@ -55,5 +53,29 @@
         proxy_pass_header Authorization;
         proxy_pass http://my_backend_api;
 
+        access_log /var/log/nginx/access.log main_jwt;
+    }
+
+    # For testing a proxied backend API w/ bearer token without cookie:
+    location /v1/api/4 {
+        status_zone     api_4;
+        set $proxy_id   'proxy_4';
+        js_content      oidc.passProxyWithToken;
+        access_log /var/log/nginx/access.log main_jwt;
+    }
+
+    # For testing a proxied backend API w/ bearer token without cookie:
+    location /v1/api/5 {
+        status_zone     api_5;
+        set $proxy_id   'proxy_5';
+        js_content      oidc.passProxyWithToken;
+        access_log /var/log/nginx/access.log main_jwt;
+    }
+
+    # For testing a proxied backend API w/ bearer token without cookie:
+    location /v1/api/6 {
+        status_zone api_6;
+        js_content oidc.setIdAccessTokenToProxy;
+        proxy_pass http://my_backend_api;
         access_log /var/log/nginx/access.log main_jwt;
     }

--- a/examples/build-context/nginx/conf.d/sample_proxied_api.conf
+++ b/examples/build-context/nginx/conf.d/sample_proxied_api.conf
@@ -28,13 +28,31 @@ server {
     # For testing an API endpoint w/ cookie + bearer access token.
     location /v1/api/2 {
         default_type application/json;
-        js_content oidc.testExtractBearerToken;
+        js_content oidc.testExtractToken;
     }
 
     # For testing an API endpoint w/ bearer token without cookie.
     location /v1/api/3 {
         default_type application/json;
-        js_content oidc.testExtractBearerToken;
+        js_content oidc.testExtractToken;
+    }
+
+    # For testing an API endpoint w/ bearer token without cookie.
+    location /v1/api/4 {
+        default_type application/json;
+        js_content oidc.testExtractToken;
+    }
+
+    # For testing an API endpoint w/ bearer token without cookie.
+    location /v1/api/5 {
+        default_type application/json;
+        js_content oidc.testExtractToken;
+    }
+
+    # For testing an API endpoint w/ bearer token without cookie.
+    location /v1/api/6 {
+        default_type application/json;
+        js_content oidc.testExtractToken;
     }
 
     # For testing a bearer token validation.


### PR DESCRIPTION
- **Problem**:
Current NJS implementation doesn't have ability for customers to choose which token(s) - access_token & id_token - they want to use it in the client application (SPA) or in backend service. 

- **Change required**:
Capture map variables returnTokenToClientOnLogin & forwardTokenToBackend with respective values.

  - For `returnTokenToClientOnLogin`, this config is only effective for /login endpoint exposed above. By default, our implementation MUST not return any token back to the client app. If its configured it can send id_token in the request uri as ?id_token=sdfsdfdsfs after successful login. 

  - For `forwardTokenToBackend,` this config is always effective as default this forward access_token as Bearer token. However this can be configured to just forward the id_token in the request header as x-id-token : sdfdsfdsfds . If its configured to forward both then the proxy request header would have Authorization : Bearer <access_token> & x-id-token : sdfdsfdsfds . If its configured as none then NO token(s) get forwarded to the backend service.

- **Assumptions**:
  - Its assumed the id_token and access_token sent to the client app or to the backend service would take care of the validity and integerity of the token(s) , even it has been validated by the nginx+.
  - Its expected that nginx+ would always verify the token(s) validity and integrity before sending it to the client or backend

