### PR TITLE
fix: remove unused code and query param for custom logout

### DIFF
--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -199,7 +199,7 @@ function logout(r) {
         r.return(302, r.variables.oidc_logout_endpoint + 
                       getRPInitiatedLogoutArgs(r, idToken));
     } else {
-        r.return(302, r.variables.oidc_logout_endpoint + 
+        r.return(302, r.variables.oidc_logout_endpoint + '?' +
                       r.variables.oidc_logout_query_params
             );
     }

--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -51,8 +51,6 @@ map $host $oidc_logout_endpoint {
     default                 "http://my-idp:8080/auth/realms/master/protocol/openid-connect/logout";
     mynginxoidc.aws         "https://my-nginx-plus.auth.us-east-2.amazoncognito.com/logout";
     mynginxpkce.aws         "https://my-nginx-plus.auth.us-east-2.amazoncognito.com/logout";
-    # mynginxoidc.aws         "https://my-nginx-plus.auth.us-east-2.amazoncognito.com/oauth2/logout";
-    # mynginxpkce.aws         "https://my-nginx-plus.auth.us-east-2.amazoncognito.com/oauth2/logout";
     mynginxoidc.onelogin    "https://my-nginx-plus.onelogin.com/oidc/2/logout";
     mynginxpkce.onelogin    "https://my-nginx-plus.onelogin.com/oidc/2/logout";
     mynginxoidc.okta        "https://dev-9590480.okta.com/oauth2/v1/logout";


### PR DESCRIPTION
- Remove unused code for logout endpoint for Amazon Cognito.
- Add query param symbol to the logout endpoint.