### PR TITLE
feat: generate custom query parameters for OIDC auth endpoint

### DIFF
--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -449,6 +449,7 @@ function getAuthZArgs(r) {
         'auth_redir=' + r.variables.request_uri + '; ' + cookieFlags,
         'auth_nonce=' + noncePlain + '; ' + cookieFlags
     ];
+    r.variables.nonce_hash = nonceHash;
 
     if (r.variables.oidc_pkce_enable == 1) {
         var pkce_code_verifier  = c.createHmac('sha256', r.variables.oidc_hmac_key).
@@ -464,7 +465,21 @@ function getAuthZArgs(r) {
     } else {
         authZArgs += '&state=0';
     }
+
+    if (r.variables.oidc_custom_authz_enable == 1) {
+        return generateQueryParams(r.variables.oidc_custom_authz_query_params);
+    }
     return authZArgs;
+}
+
+// Generate custom query parameters from JSON object
+function generateQueryParams(items) {
+    var items = JSON.parse(items);
+    var args = '?'
+    for (var key in items) {
+        args += key + '=' + items[key] + '&'
+    }
+    return args.slice(0, -1)
 }
 
 // Generate and return random string.

--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -138,6 +138,28 @@ map $host $oidc_logout_query_params {
     mynginxoidc.keycloak    "";
 }
 
+map $host $oidc_custom_authz_enable {
+    default                 0;
+    mynginxoidc.okta        1;
+}
+
+map $host $oidc_custom_authz_query_params {
+    default                 "";
+    mynginxoidc.okta        '{
+        "response_type": "code",
+        "scope"        : "$oidc_scopes",
+        "client_id"    : "$oidc_client",
+        "redirect_uri" : "$redirect_base$redir_location",
+        "nonce"        : "$nonce_hash",
+        "state"        : 0
+    }';
+}
+
+map $host $oidc_custom_authz_path_params {
+    default                 "";
+    mynginxoidc.okta        '[{"ver": "v1"}]';
+}
+
 map $host $oidc_hmac_key {
     # This should be unique for every NGINX instance/cluster
     default                 "ChangeMe";
@@ -206,7 +228,10 @@ keyval_zone zone=oidc_access_tokens:1M   state=conf.d/oidc_access_tokens.json  t
 keyval_zone zone=oidc_refresh_tokens:1M  state=conf.d/oidc_refresh_tokens.json timeout=8h;
 
 # Temporary storage for PKCE code verifier.
-keyval_zone zone=oidc_pkce:128K                                                timeout=90s;
+keyval_zone zone=oidc_pkce:128K          timeout=90s;
+
+# Temporary storage for NONCE.
+keyval_zone zone=oidc_nonce_hash:128K    timeout=90s;
 
 keyval $cookie_auth_token $id_token           zone=oidc_id_tokens;       # Exchange cookie for ID      token
 keyval $cookie_auth_token $access_token       zone=oidc_access_tokens;   # Exchange cookie for access  token
@@ -214,6 +239,7 @@ keyval $cookie_auth_token $refresh_token      zone=oidc_refresh_tokens;  # Excha
 keyval $request_id        $new_id_token       zone=oidc_id_tokens;       # For initial session creation for ID token
 keyval $request_id        $new_access_token   zone=oidc_access_tokens;   # For initial session creation for access token
 keyval $request_id        $new_refresh        zone=oidc_refresh_tokens;  # ''
+keyval $request_id        $nonce_hash         zone=oidc_nonce_hash;      # ''
 keyval $pkce_id           $pkce_code_verifier zone=oidc_pkce;
 
 auth_jwt_claim_set $jwt_audience aud; # In case aud is an array

--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -155,11 +155,6 @@ map $host $oidc_custom_authz_query_params {
     }';
 }
 
-map $host $oidc_custom_authz_path_params {
-    default                 "";
-    mynginxoidc.okta        '[{"ver": "v1"}]';
-}
-
 map $host $oidc_hmac_key {
     # This should be unique for every NGINX instance/cluster
     default                 "ChangeMe";

--- a/examples/build-context/nginx/conf.d/oidc_server.conf
+++ b/examples/build-context/nginx/conf.d/oidc_server.conf
@@ -1,7 +1,6 @@
     # Advanced configuration START
     set $internal_error_message "NGINX / OIDC login failure\n";
     set $pkce_id "";
-    set $proxy_id "";
     resolver 8.8.8.8; # For DNS lookup of IdP endpoints;
     subrequest_output_buffer_size 32k; # To fit a complete tokenset response
     gunzip on; # Decompress IdP responses if necessary

--- a/examples/build-context/nginx/conf.d/sample_proxied_api.conf
+++ b/examples/build-context/nginx/conf.d/sample_proxied_api.conf
@@ -22,7 +22,10 @@ server {
     location /v1/api/1 {
         default_type application/json;
         return 200 
-        '{"code": "1", "message": "tested /v1/api/1 without token."}\n';
+        '{
+            "code": "1", 
+            "message": "tested /v1/api/1 without token."
+        }\n';
     }
 
     # For testing an API endpoint w/ cookie + bearer access token.


### PR DESCRIPTION
- Func. to generate custom query parameters
- Generate custom query params for OIDC authorization endpoint
- Add map and key value zone for custom query param for OIDC authorization. 
  - `$oidc_custom_authz_enable`
  - `$oidc_custom_authz_query_params`
  - `$nonce_hash`
  - `$oidc_nonce_hash`