### PR TITLE
feat: custom query param for OIDC token endpoint

### DIFF
--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -118,13 +118,13 @@ map $host $oidc_logout_redirect {
 map $host $oidc_custom_logout_query_params_enable {
     # The OIDC RP-initiated logout standard is proceeded if this isn't enabled.
     default                 0;
-    mynginxoidc.aws         0;
-    mynginxpkce.aws         0;
-    mynginxoidc.onelogin    1;
-    mynginxpkce.onelogin    1;
-    mynginxoidc.okta        1;
-    mynginxpkce.okta        1;
-    mynginxoidc.keycloak    0;
+    mynginxoidc.aws         1;
+    mynginxpkce.aws         1;
+    mynginxoidc.onelogin    0;
+    mynginxpkce.onelogin    0;
+    mynginxoidc.okta        0;
+    mynginxpkce.okta        0;
+    mynginxoidc.keycloak    1;
 }
 
 map $host $oidc_custom_logout_query_params {
@@ -148,7 +148,7 @@ map $host $oidc_custom_logout_query_params {
     mynginxoidc.keycloak    "";
 }
 
-map $host $oidc_custom_authz_enable {
+map $host $oidc_custom_authz_query_params_enable {
     default                 0;
     mynginxoidc.okta        1;
 }
@@ -163,6 +163,16 @@ map $host $oidc_custom_authz_query_params {
         "nonce"        : "$nonce_hash",
         "state"        : 0
     }';
+}
+
+map $host $oidc_custom_token_query_params_enable {
+    default                 0;
+    mynginxoidc.okta        1;
+}
+
+map $host $oidc_custom_token_query_params {
+    default                 "";
+    mynginxoidc.okta        '{ "example": "data" }';
 }
 
 map $host $oidc_hmac_key {
@@ -233,19 +243,19 @@ keyval_zone zone=oidc_id_tokens:1M       state=conf.d/oidc_id_tokens.json      t
 keyval_zone zone=oidc_access_tokens:1M   state=conf.d/oidc_access_tokens.json  timeout=1h;
 keyval_zone zone=oidc_refresh_tokens:1M  state=conf.d/oidc_refresh_tokens.json timeout=8h;
 
-# Temporary storage for PKCE code verifier.
-keyval_zone zone=oidc_pkce:128K          timeout=90s;
+# Temporary storages.
+keyval_zone zone=oidc_pkce:128K                 timeout=90s; # for PKCE code verifier
+keyval_zone zone=oidc_nonce_hash:128K           timeout=90s; # for NONCE
+keyval_zone zone=oidc_token_query_params:128K   timeout=90s; # for query params of token endpoint
 
-# Temporary storage for NONCE.
-keyval_zone zone=oidc_nonce_hash:128K    timeout=90s;
-
-keyval $cookie_auth_token $id_token           zone=oidc_id_tokens;       # Exchange cookie for ID      token
-keyval $cookie_auth_token $access_token       zone=oidc_access_tokens;   # Exchange cookie for access  token
-keyval $cookie_auth_token $refresh_token      zone=oidc_refresh_tokens;  # Exchange cookie for refresh token
-keyval $request_id        $new_id_token       zone=oidc_id_tokens;       # For initial session creation for ID token
-keyval $request_id        $new_access_token   zone=oidc_access_tokens;   # For initial session creation for access token
-keyval $request_id        $new_refresh        zone=oidc_refresh_tokens;  # ''
-keyval $request_id        $nonce_hash         zone=oidc_nonce_hash;      # ''
+keyval $cookie_auth_token $id_token           zone=oidc_id_tokens;          # Exchange cookie for ID      token
+keyval $cookie_auth_token $access_token       zone=oidc_access_tokens;      # Exchange cookie for access  token
+keyval $cookie_auth_token $refresh_token      zone=oidc_refresh_tokens;     # Exchange cookie for refresh token
+keyval $request_id        $new_id_token       zone=oidc_id_tokens;          # For initial session creation for ID token
+keyval $request_id        $new_access_token   zone=oidc_access_tokens;      # For initial session creation for access token
+keyval $request_id        $new_refresh        zone=oidc_refresh_tokens;     # For initial session creation for refresh token
+keyval $request_id        $nonce_hash         zone=oidc_nonce_hash;         # For NONCE
+keyval $request_id        $token_query_params zone=oidc_token_query_params; # for query params of token endpoint
 keyval $pkce_id           $pkce_code_verifier zone=oidc_pkce;
 
 auth_jwt_claim_set $jwt_audience aud; # In case aud is an array

--- a/examples/build-context/nginx/conf.d/oidc_server.conf
+++ b/examples/build-context/nginx/conf.d/oidc_server.conf
@@ -31,29 +31,29 @@
         js_content oidc.codeExchange;
         error_page 500 502 504 @oidc_error; 
     }
-   
+
     location = /_token {
         # This location is called by oidc.codeExchange(). We use the proxy_ 
         # directives to construct the OIDC token request, as per:
         #  http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
-        internal;
+        # internal;
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=authorization_code&client_id=$oidc_client&$args&redirect_uri=$redirect_base$redir_location";
         proxy_method          POST;
-        proxy_pass            $oidc_token_endpoint;
+        proxy_pass            $oidc_token_endpoint$token_query_params;
     }
 
     location = /_refresh {
         # This location is called by oidc.auth() when performing a token refresh.
         # We use the proxy_ directives to construct the OIDC token request, as per:
         #  https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
-        internal;
+        # internal;
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=refresh_token&refresh_token=$arg_token&client_id=$oidc_client&client_secret=$oidc_client_secret";
         proxy_method          POST;
-        proxy_pass            $oidc_token_endpoint;
+        proxy_pass            $oidc_token_endpoint$token_query_params;
     }
 
     location = /_id_token_validation {

--- a/examples/build-context/nginx/conf.d/oidc_server.conf
+++ b/examples/build-context/nginx/conf.d/oidc_server.conf
@@ -36,7 +36,7 @@
         # This location is called by oidc.codeExchange(). We use the proxy_ 
         # directives to construct the OIDC token request, as per:
         #  http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
-        # internal;
+        internal;
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=authorization_code&client_id=$oidc_client&$args&redirect_uri=$redirect_base$redir_location";
@@ -48,7 +48,7 @@
         # This location is called by oidc.auth() when performing a token refresh.
         # We use the proxy_ directives to construct the OIDC token request, as per:
         #  https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
-        # internal;
+        internal;
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=refresh_token&refresh_token=$arg_token&client_id=$oidc_client&client_secret=$oidc_client_secret";


### PR DESCRIPTION
- Add `$oidc_custom_token_query_params_enable` map to enable custom query params for IDP token endpoint.
- Add `$oidc_custom_token_query_params` map to manage custom query params per each IDP.
- Func. to set custom query params to the OIDC token endpoint. (new token, refresh token)
- Add temporary key/value zone to pass proxy of IDP token endpoint with the query param in `nginx.conf`
- Fix custom logout enable option