### PR TITLE
feat: OIDC authorization endpoint w/ custom path params

### DIFF
--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -219,10 +219,17 @@ function logout(r) {
 // Generate custom endpoint using path parameters if the option is enable.
 // Otherwise, return the original endpoint.
 //
+// [Example 1]
 // - Input : "https://{my-app}.okta.com/oauth2/{version}/logout"
 //   + {my-app}  -> 'dev-9590480'
 //   + {version} -> 'v1'
 // - Result: "https://dev-9590480.okta.okta.com/oauth2/v1/logout"
+//
+// [Example 2]
+// - Input : "https://{my-app}.okta.com/oauth2/{version}/authorize"
+//   + {my-app}  -> 'dev-9590480'
+//   + {version} -> 'v1'
+// - Result: "https://dev-9590480.okta.okta.com/oauth2/v1/authorize"
 //
 function generateCustomEndpoint(r, uri, isEnableCustomPath, paths) {
     if (isEnableCustomPath == 0) {

--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -279,6 +279,12 @@ function startIdPAuthZ(r) {
 
     var configs = ['authz_endpoint', 'scopes', 'hmac_key', 'cookie_flags'];
     var missingConfig = [];
+    var authz_endpoint = generateCustomEndpoint(r,
+        r.variables.oidc_authz_endpoint,
+        r.variables.oidc_custom_authz_path_params_enable,
+        r.variables.oidc_custom_authz_path_params
+    );
+
     for (var i in configs) {
         var oidcCfg = r.variables['oidc_' + configs[i]]
         if (!oidcCfg || oidcCfg == '') {
@@ -290,7 +296,7 @@ function startIdPAuthZ(r) {
         r.return(500, r.variables.internal_error_message);
         return;
     }
-    r.return(302, r.variables.oidc_authz_endpoint + getAuthZArgs(r));
+    r.return(302, authz_endpoint + getAuthZArgs(r));
 }
 
 // Handle error response regarding the referesh token received from IDP:

--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -9,7 +9,7 @@ map $host $oidc_authz_endpoint {
     mynginxpkce.aws         "https://my-nginx-plus.auth.us-east-2.amazoncognito.com/oauth2/authorize";
     mynginxoidc.onelogin    "https://my-nginx-plus.onelogin.com/oidc/2/auth";
     mynginxpkce.onelogin    "https://my-nginx-plus.onelogin.com/oidc/2/auth";
-    mynginxoidc.okta        "https://dev-9590480.okta.com/oauth2/v1/authorize";
+    mynginxoidc.okta        "https://{my-app}.okta.com/oauth2/{version}/authorize";
     mynginxpkce.okta        "https://dev-9590480.okta.com/oauth2/v1/authorize";
     mynginxoidc.keycloak    "http://my-idp:8080/auth/realms/master/protocol/openid-connect/auth";
 }
@@ -166,6 +166,11 @@ map $host $oidc_custom_authz_query_params_enable {
     mynginxoidc.okta        1;
 }
 
+map $host $oidc_custom_authz_path_params_enable {
+    default                 0;
+    mynginxoidc.okta        1;
+}
+
 map $host $oidc_custom_authz_query_params {
     default                 "";
     mynginxoidc.okta        '{
@@ -175,6 +180,14 @@ map $host $oidc_custom_authz_query_params {
         "redirect_uri" : "$redirect_base$redir_location",
         "nonce"        : "$nonce_hash",
         "state"        : 0
+    }';
+}
+
+map $host $oidc_custom_authz_path_params {
+    default                 0;
+    mynginxoidc.okta        '{
+        "my-app" : "dev-9590480",
+        "version": "v1"
     }';
 }
 


### PR DESCRIPTION
- Map to enable custom path params
- Map JSON object of custom path params per host for the spec of OIDC authorization endpoint
- Generate path params from the key/value items using the map of custom path params
- Handle OIDC authorization endpoint with custom path params
- Test w/ Okta and Amazon Cognito
  - None custom path params
  - Multiple custom path params
- Example
   ```
    - Input : "https://{my-app}.okta.com/oauth2/{version}/authorize"
      + {my-app}  -> 'dev-9590480'
      + {version} -> 'v1'
    - Result: "https://dev-9590480.okta.okta.com/oauth2/v1/authorize"
   ```