### PR TITLE
feat: OIDC token endpoint with custom path params

### DIFF
--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -257,6 +257,7 @@ function generateCustomEndpoint(r, uri, isEnableCustomPath, paths) {
                 }
         }
     }
+    r.log('generated an endpoint using path params: ' + res)
     return res;
 }
 

--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -402,7 +402,8 @@ function refershToken(r) {
     }
 }
 
-// Set token query parameters if customization option of query params is enable.
+// Set query/path parameters to the IDP token endpoint if customization option 
+// for query or path param is enable.
 function setTokenParams(r) {
     clearTokenParams(r)
     if (r.variables.oidc_custom_token_query_params_enable == 1) {

--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -74,12 +74,12 @@ function codeExchange(r) {
     if (!isValidAuthZCode(r)) {
         return
     }
-    setTokenQueryParams(r)
+    setTokenParams(r)
     r.subrequest('/_token', getTokenArgs(r),
         function(res) {
             var isErr = handleTokenErrorResponse(r, res)
             if (isErr) {
-                clearTokenQueryParams(r)
+                clearTokenParams(r)
                 return
             }
             handleSuccessfulTokenResponse(r, res)
@@ -389,12 +389,12 @@ function handleSuccessfulRefreshResponse(r, res) {
 //  - https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse
 //
 function refershToken(r) {
-    setTokenQueryParams(r)
+    setTokenParams(r)
     r.subrequest('/_refresh', 'token=' + r.variables.refresh_token, respHandler);
     function respHandler(res) {
         if (res.status != 200) {
             handleRefershErrorResponse(r, res);
-            clearTokenQueryParams(r)
+            clearTokenParams(r)
             return;
         }
         handleSuccessfulRefreshResponse(r, res);
@@ -402,18 +402,23 @@ function refershToken(r) {
 }
 
 // Set token query parameters if customization option of query params is enable.
-function setTokenQueryParams(r) {
-    clearTokenQueryParams(r)
+function setTokenParams(r) {
+    clearTokenParams(r)
     if (r.variables.oidc_custom_token_query_params_enable == 1) {
         r.variables.token_query_params = generateQueryParams(
             r.variables.oidc_custom_token_query_params
         );
     }
+    r.variables.oidc_custom_token_endpoint = generateCustomEndpoint(r,
+        r.variables.oidc_token_endpoint,
+        r.variables.oidc_custom_token_path_params_enable,
+        r.variables.oidc_custom_token_path_params
+    );
 }
 
 // Clear token query parameters from the temporary stroage of NGINX if OIDC's
 // token endpoint returns error.
-function clearTokenQueryParams(r) {
+function clearTokenParams(r) {
     r.variables.token_query_params = '';
 }
 

--- a/examples/build-context/nginx/conf.d/oidc.js
+++ b/examples/build-context/nginx/conf.d/oidc.js
@@ -418,8 +418,8 @@ function setTokenParams(r) {
     );
 }
 
-// Clear token query parameters from the temporary stroage of NGINX if OIDC's
-// token endpoint returns error.
+// Clear query parameters of the temporary stroage for the NGINX if OIDC's token
+// endpoint returns error.
 function clearTokenParams(r) {
     r.variables.token_query_params = '';
 }

--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -3,7 +3,7 @@
 # Each map block allows multiple values so that multiple IdPs can be supported,
 # the $host variable is used as the default input parameter but can be changed.
 #
-variables_hash_max_size    2048;
+variables_hash_max_size    4096;
 
 map $host $oidc_authz_endpoint {
     default                 "http://my-idp:8080/auth/realms/master/protocol/openid-connect/auth";
@@ -27,16 +27,16 @@ map $host $oidc_token_endpoint {
     mynginxoidc.keycloak    "http://my-idp:8080/auth/realms/master/protocol/openid-connect/token";
 }
 
-# map $host $oidc_custom_token_endpoint {
-#     default                 $oidc_token_endpoint;
-#     mynginxoidc.aws         $oidc_token_endpoint;
-#     mynginxpkce.aws         $oidc_token_endpoint;
-#     mynginxoidc.onelogin    $oidc_token_endpoint;
-#     mynginxpkce.onelogin    $oidc_token_endpoint;
-#     mynginxoidc.okta        $oidc_token_endpoint;
-#     mynginxpkce.okta        $oidc_token_endpoint;
-#     mynginxoidc.keycloak    $oidc_token_endpoint;
-# }
+map $host $oidc_custom_token_endpoint {
+    default                 $oidc_token_endpoint;
+    mynginxoidc.aws         $oidc_token_endpoint;
+    mynginxpkce.aws         $oidc_token_endpoint;
+    mynginxoidc.onelogin    $oidc_token_endpoint;
+    mynginxpkce.onelogin    $oidc_token_endpoint;
+    mynginxoidc.okta        $oidc_token_endpoint;
+    mynginxpkce.okta        $oidc_token_endpoint;
+    mynginxoidc.keycloak    $oidc_token_endpoint;
+}
 
 map $host $oidc_jwt_keyfile {
     default                 "http://my-idp:8080/auth/realms/master/protocol/openid-connect/certs";

--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -3,6 +3,8 @@
 # Each map block allows multiple values so that multiple IdPs can be supported,
 # the $host variable is used as the default input parameter but can be changed.
 #
+variables_hash_max_size    2048;
+
 map $host $oidc_authz_endpoint {
     default                 "http://my-idp:8080/auth/realms/master/protocol/openid-connect/auth";
     mynginxoidc.aws         "https://my-nginx-plus.auth.us-east-2.amazoncognito.com/oauth2/authorize";
@@ -20,10 +22,21 @@ map $host $oidc_token_endpoint {
     mynginxpkce.aws         "https://my-nginx-plus.auth.us-east-2.amazoncognito.com/oauth2/token";
     mynginxoidc.onelogin    "https://my-nginx-plus.onelogin.com/oidc/2/token";
     mynginxpkce.onelogin    "https://my-nginx-plus.onelogin.com/oidc/2/token";
-    mynginxoidc.okta        "https://dev-9590480.okta.com/oauth2/v1/token";
+    mynginxoidc.okta        "https://{my-app}.okta.com/oauth2/{version}/token";
     mynginxpkce.okta        "https://dev-9590480.okta.com/oauth2/v1/token";
     mynginxoidc.keycloak    "http://my-idp:8080/auth/realms/master/protocol/openid-connect/token";
 }
+
+# map $host $oidc_custom_token_endpoint {
+#     default                 $oidc_token_endpoint;
+#     mynginxoidc.aws         $oidc_token_endpoint;
+#     mynginxpkce.aws         $oidc_token_endpoint;
+#     mynginxoidc.onelogin    $oidc_token_endpoint;
+#     mynginxpkce.onelogin    $oidc_token_endpoint;
+#     mynginxoidc.okta        $oidc_token_endpoint;
+#     mynginxpkce.okta        $oidc_token_endpoint;
+#     mynginxoidc.keycloak    $oidc_token_endpoint;
+# }
 
 map $host $oidc_jwt_keyfile {
     default                 "http://my-idp:8080/auth/realms/master/protocol/openid-connect/certs";
@@ -154,7 +167,7 @@ map $host $oidc_custom_logout_query_params {
 }
 
 map $host $oidc_custom_logout_path_params {
-    default                 0;
+    default                 "";
     mynginxoidc.okta        '{
         "my-app" : "dev-9590480",
         "version": "v1"
@@ -184,7 +197,7 @@ map $host $oidc_custom_authz_query_params {
 }
 
 map $host $oidc_custom_authz_path_params {
-    default                 0;
+    default                 "";
     mynginxoidc.okta        '{
         "my-app" : "dev-9590480",
         "version": "v1"
@@ -196,9 +209,22 @@ map $host $oidc_custom_token_query_params_enable {
     mynginxoidc.okta        1;
 }
 
+map $host $oidc_custom_token_path_params_enable {
+    default                 0;
+    mynginxoidc.okta        1;
+}
+
 map $host $oidc_custom_token_query_params {
     default                 "";
     mynginxoidc.okta        '{ "example": "data" }';
+}
+
+map $host $oidc_custom_token_path_params {
+    default                 "";
+    mynginxoidc.okta        '{
+        "my-app" : "dev-9590480",
+        "version": "v1"
+    }';
 }
 
 map $host $oidc_hmac_key {

--- a/examples/build-context/nginx/conf.d/oidc_server.conf
+++ b/examples/build-context/nginx/conf.d/oidc_server.conf
@@ -41,7 +41,7 @@
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=authorization_code&client_id=$oidc_client&$args&redirect_uri=$redirect_base$redir_location";
         proxy_method          POST;
-        proxy_pass            $oidc_token_endpoint$token_query_params;
+        proxy_pass            $oidc_custom_token_endpoint$token_query_params;
     }
 
     location = /_refresh {
@@ -53,7 +53,7 @@
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=refresh_token&refresh_token=$arg_token&client_id=$oidc_client&client_secret=$oidc_client_secret";
         proxy_method          POST;
-        proxy_pass            $oidc_token_endpoint$token_query_params;
+        proxy_pass            $oidc_custom_token_endpoint$token_query_params;
     }
 
     location = /_id_token_validation {


### PR DESCRIPTION
- Map to enable custom path params for IDP token endpoint
- Map JSON object of custom path params per host for the spec of OIDC token endpoint
- Handle OIDC token endpoint with custom path params
  - new token
  - refresh token
- Test w/ Okta and Amazon Cognito
  - None custom path params
  - Multiple custom path params