### PR TITLE
fix: remove unused directives

### DIFF
--- a/examples/build-context/nginx/conf.d/oidc_common.conf
+++ b/examples/build-context/nginx/conf.d/oidc_common.conf
@@ -263,7 +263,7 @@ map $host $return_token_to_client_on_login {
     # this implementation MUST not return any token back to the client app. 
     # If its configured it can send id_token in the request uri 
     # as ?id_token=sdfsdfdsfs after successful login.
-    default          "id_token"; # options: id_token or ""
+    default          ""; # options: id_token or ""
     mynginxoidc.aws  "";
 }
 

--- a/examples/build-context/nginx/conf.d/oidc_server.conf
+++ b/examples/build-context/nginx/conf.d/oidc_server.conf
@@ -104,7 +104,7 @@
         auth_jwt "" token=$access_token;
         #auth_jwt_key_file $oidc_jwt_keyfile;   # Enable when using filename
         auth_jwt_key_request /_jwks_uri;        # Enable when using URL
-        proxy_pass_request_headers on;
+        
         proxy_set_header Authorization "Bearer $access_token";
         proxy_set_header x-id-token    "$id_token";
         proxy_pass $backend_proxy$request_uri;


### PR DESCRIPTION
- remove unused directives: `proxy_pass_request_headers on;`
- set default map (`$return_token_to_client_on_login`) with empty value not to return query params on login.