### PR TITLE
feat: Using client-id to identify the client application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: start watch down clean clean-cache unit-test functional-test test
+
+start:
+	docker-compose up -d
+
+ps:
+	docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Ports}}\t{{.Names}}"
+
+watch:
+	watch 'docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Ports}}\t{{.Names}}"'
+
+down:
+	docker-compose down
+
+clean: 
+	docker kill $$(docker ps -q) 2> /dev/null || true
+	docker system prune -a
+	docker volume rm $(docker volume ls -qf dangling=true)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,11 @@ networks:
 services:
 
   postgres:
-      image: postgres:12.0-alpine
+      container_name: idp-db
+      image: postgres:12.0
       volumes:
         - type: bind
-          source: $IDP_DATA_PATH
+          source: ./docker/build-context/data
           target: /var/lib/postgresql/data
       environment:
         POSTGRES_DB: keycloak
@@ -23,6 +24,7 @@ services:
        - mynetwork
         
   keycloak:
+    container_name: idp-keycloak
     image: jboss/keycloak:15.1.0
     environment:
       DB_VENDOR: POSTGRES
@@ -43,6 +45,7 @@ services:
       - mynetwork
 
   nginx_plus_ubuntu18.04:
+    container_name: nginx-plus-oidc
     build:
       context: ./
       dockerfile: ./docker/docker-files/nginxplus-ubuntu18.04/Dockerfile
@@ -52,10 +55,10 @@ services:
       - 8010:8010
     volumes:
       - type: bind
-        source: $NGINX_CONF_PATH
+        source: ./
         target: /etc/nginx/conf.d/
       - type: bind
-        source: $NGINX_HTML_PATH
+        source: ./docker/build-context/content
         target: /usr/share/nginx/html/
     networks:
       - mynetwork

--- a/docker/README.md
+++ b/docker/README.md
@@ -91,9 +91,6 @@ Set up your local environment for testing OIDC workflows based on NGINX Plus doc
 - **Run a Docker container based on the image:**
   This is to locally edit files and reload `nginx -s reload` for your convenient testing in container(s).
   ```bash
-  $ NGINX_CONF_PATH=/Users/{user name}/{your github path}/
-  $ NGINX_HTML_PATH=/Users/{user name}/{your github path}/build-context/content
-  $ IDP_DATA_PATH=/Users/{user name}/{your github path}/build-context/data
   $ docker-compose up -d
   ```
 

--- a/docker/build-context/content/index.html
+++ b/docker/build-context/content/index.html
@@ -30,8 +30,12 @@
               />
             </div>
           </div>
-          <button type="submit" id="signin">Sign in</button><br>
+          
+          <br>
+          <h4>Enter an IdP app's client ID:</h4>
           <input type="text" id="client-id" value="my-client-id" name="client-id" />
+
+          <button type="submit" id="signin">Sign in</button>
           <button type="submit" id="id-token">Get ID Token</button>
           <button type="submit" id="ac-token">Get Access Token</button>
           <button type="submit" id="cookie">Get Cookie</button>

--- a/docker/build-context/nginx/test_oidc_token.conf
+++ b/docker/build-context/nginx/test_oidc_token.conf
@@ -32,7 +32,7 @@
     # Test for retrieving cookie from the key/value store
     location = /cookie {
         default_type application/json;
-        set $response '{ "cookie" : "session_id=${cookie_session_id}" }';
+        set $response '{ "cookie" : "client_id=${x_client_id}; session_id=${cookie_session_id}" }';
         return 200 $response;
     }
 

--- a/oidc.js
+++ b/oidc.js
@@ -39,9 +39,9 @@ export default {
 
 // Start OIDC with either intializing new session or refershing token:
 //
-// 1. Validate X-Client-Id
-//  - Check if X-Client-Id is provided in query params of /login endpoint if the
-//    variable of `$x_client_id_validation_enable` is true.
+// 1. Validate client_id
+//  - Check if client_id is provided in the cookie of /login endpoint if the
+//    variable of `$client_id_validation_enable` is true.
 //  - Otherwise, default IdP's application can be used.
 //  - `$x_client_id` is for customer to identity one of applications so that this
 //    mechanism supports multiple IdPs.
@@ -792,10 +792,10 @@ function validateSession(r) {
 
 // Check if `X-Client-Id` is in query params of HTTP request, and if the name of
 // IdP's app is matched with the `$x_client_id` so that we can validate it is
-// valid when logging-in if `x_client_id_validation_enable` is enabled.
+// valid when logging-in if `client_id_validation_enable` is enabled.
 //
 function isValidXClientId(r) {
-    if (r.variables.x_client_id_validation_enable == 1) {
+    if (r.variables.client_id_validation_enable == 1) {
         if (!r.variables.cookie_client_id) {
             r.warn(ERR_X_CLIENT_ID_COOKIE)
             r.return(400, '{"message": "' + ERR_X_CLIENT_ID_COOKIE + '"}\n')

--- a/oidc_idp.conf
+++ b/oidc_idp.conf
@@ -66,7 +66,7 @@ map $x_client_id $oidc_host {
     # - Okta      https://dev-9590481.okta.com
     default                 http://host.docker.internal:8080;
     my-client-id            http://host.docker.internal:8080;
-    0oa1u2c1p0QgIiGKX5d7    https://dev-9590480.okta.com;
+    0oa1u2c1p0QgIiGKX5d7    https://dev-xxxxxx.okta.com;
 }
 
 # ---------------------------------------------------------------------------- #

--- a/oidc_idp.conf
+++ b/oidc_idp.conf
@@ -25,39 +25,48 @@
 # ---------------------------------------------------------------------------- #
 
 map $x_client_id $oidc_authz_endpoint {
-    default                 "http://host.docker.internal:8080/auth/realms/master/protocol/openid-connect/auth";
+    default                 $oidc_host/auth/realms/master/protocol/openid-connect/auth;
     my-client-id            "http://{my-fqdn}/auth/realms/{version}/protocol/openid-connect/auth";
-    0oa1u2c1p0QgIiGKX5d7    "https://dev-9590480.okta.com/oauth2/v1/authorize";
+    0oa1u2c1p0QgIiGKX5d7    $oidc_host/oauth2/v1/authorize;
 }
 
 map $x_client_id $oidc_jwt_keyfile {
-    default                 "http://host.docker.internal:8080/auth/realms/master/protocol/openid-connect/certs";
-    my-client-id            "http://host.docker.internal:8080/auth/realms/master/protocol/openid-connect/certs";
-    0oa1u2c1p0QgIiGKX5d7    "https://dev-9590480.okta.com/oauth2/v1/keys";
+    default                 $oidc_host/auth/realms/master/protocol/openid-connect/certs;
+    my-client-id            $oidc_host/auth/realms/master/protocol/openid-connect/certs;
+    0oa1u2c1p0QgIiGKX5d7    $oidc_host/oauth2/v1/keys;
 }
 
 map $x_client_id $oidc_logout_endpoint {
-    default                 "http://host.docker.internal:8080/auth/realms/master/protocol/openid-connect/logout";
+    default                 $oidc_host/auth/realms/master/protocol/openid-connect/logout;
     my-client-id            "http://{my-fqdn}/auth/realms/{version}/protocol/openid-connect/logout";
-    0oa1u2c1p0QgIiGKX5d7    "https://dev-9590480.okta.com/oauth2/v1/logout";
+    0oa1u2c1p0QgIiGKX5d7    $oidc_host/oauth2/v1/logout;
 }
 
 map $x_client_id $oidc_token_endpoint {
-    default                 "http://host.docker.internal:8080/auth/realms/master/protocol/openid-connect/token";
+    default                 $oidc_host/auth/realms/master/protocol/openid-connect/token;
     my-client-id            "http://{my-fqdn}/auth/realms/{version}/protocol/openid-connect/token";
-    0oa1u2c1p0QgIiGKX5d7    "https://dev-9590480.okta.com/oauth2/v1/token";
+    0oa1u2c1p0QgIiGKX5d7    $oidc_host/oauth2/v1/token;
 }
 
 map $x_client_id $oidc_userinfo_endpoint {
-    default                 "http://host.docker.internal:8080/auth/realms/master/protocol/openid-connect/userinfo";
-    my-client-id            "http://host.docker.internal:8080/auth/realms/master/protocol/openid-connect/userinfo";
-    0oa1u2c1p0QgIiGKX5d7    "https://dev-9590480.okta.com/oauth2/v1/userinfo";
+    default                 $oidc_host/auth/realms/master/protocol/openid-connect/userinfo;
+    my-client-id            $oidc_host/auth/realms/master/protocol/openid-connect/userinfo;
+    0oa1u2c1p0QgIiGKX5d7    $oidc_host/oauth2/v1/userinfo;
 }
 
 map $x_client_id $oidc_scopes {
     default                 "openid+profile+email+offline_access";
     my-client-id            "openid+profile+email+offline_access";
     0oa1u2c1p0QgIiGKX5d7    "openid+profile+email+offline_access";
+}
+
+map $x_client_id $oidc_host {
+    # Examples for OIDC host:
+    # - Keycloak: http://host.docker.internal:8080
+    # - Okta      https://dev-9590481.okta.com
+    default                 http://host.docker.internal:8080;
+    my-client-id            http://host.docker.internal:8080;
+    0oa1u2c1p0QgIiGKX5d7    https://dev-9590480.okta.com;
 }
 
 # ---------------------------------------------------------------------------- #
@@ -144,7 +153,7 @@ map $x_client_id $oidc_client {
 
 map $x_client_id $oidc_client_secret {
     default                 "my-client-secret";
-    my-client-id            "my-client-secret";
+    my-client-id            "781b60a6-8279-43dd-9cbc-cc98329ce2a7";
     0oa1u2c1p0QgIiGKX5d7    "my-client-secret";
 }
 

--- a/oidc_nginx_http.conf
+++ b/oidc_nginx_http.conf
@@ -61,8 +61,8 @@ map $x_client_id $session_id_time_enable {
     default 0; # 1: timestamp(hh:mm) is included in session ID
 }
 
-map $x_client_id $x_client_id_validation_enable {
-    default 1; # 1: check if `X-Client-Id` is included in query param when login
+map $x_client_id $client_id_validation_enable {
+    default 1; # 1: check if `client_id` is included in cookie when login
 }
 
 map $cookie_client_id $x_client_id {

--- a/oidc_nginx_server.conf
+++ b/oidc_nginx_server.conf
@@ -104,7 +104,7 @@
         # This location is called by frontend to retrieve user info via the IDP.
         auth_request    /_session_validation;
         auth_request_set $session_status $upstream_status;
-        error_page 401   @session_error;
+        error_page 401 = @session_error;
 
         auth_jwt "" token=$id_token;
         auth_jwt_key_request /_jwks_uri;        # Enable when using URL


### PR DESCRIPTION
Currently OIDC RP reference implementation is using host from the http header to pick the value for OIDC endpoints; Ideally this should be done by identifying the client application. In a given enterprise, there would be hundreds of the application which would be enabled to do SSO and each one of the application might have different scopes to request from the IDP. 

- Customer will always have to identify their application from the client by sending x-client-id in the request header.
- In the reference implementation, instead of using $host to choose the value , you would use x-client-id.
- Use the value of the client ID to fetch the configured secret , scope and other values from the nginx config. If valid config is not set and there is no default value is set, throw invalid client id error. 
- Misc.
  - Makefile
  - `docker-compose`
  - Frontend UI for setting clienet-id
  - Set cookie
  - Add `oidc_host` to the IdP endpoints


